### PR TITLE
Bump base image to `debian:buster-20210408-slim`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -15,10 +15,12 @@ RUN set -eux; \
         -t buster-backports \
         libsystemd-dev=247.3-3~bpo10+1 \
         ; \
-    curl -J -L -o /tmp/loki.tar.gz "https://github.com/grafana/loki/archive/refs/tags/v${LOKI_VERSION}.tar.gz"; \
+    curl -J -L -o /tmp/loki.tar.gz \
+        "https://github.com/grafana/loki/archive/refs/tags/v${LOKI_VERSION}.tar.gz"; \
     mkdir -p /src; \
     tar -xf /tmp/loki.tar.gz -C /src; \
-    mv "/src/loki-${LOKI_VERSION}" /src/loki;
+    mv "/src/loki-${LOKI_VERSION}" /src/loki; \
+    rm /tmp/loki.tar.gz;
 
 WORKDIR /src/loki
 RUN make BUILD_IN_CONTAINER=false promtail
@@ -27,7 +29,6 @@ RUN make BUILD_IN_CONTAINER=false promtail
 FROM ${BUILD_FROM}
 
 COPY --from=build /src/loki/cmd/promtail/promtail /usr/bin/promtail
-
 RUN promtail --version
 
 # Build arguments

--- a/promtail/build.json
+++ b/promtail/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "aarch64": "arm64v8/debian:buster-20210329-slim",
-    "amd64": "amd64/debian:buster-20210329-slim",
-    "armhf": "arm32v5/debian:buster-20210329-slim",
-    "armv7": "arm32v7/debian:buster-20210329-slim"
+    "aarch64": "arm64v8/debian:buster-20210408-slim",
+    "amd64": "amd64/debian:buster-20210408-slim",
+    "armhf": "arm32v5/debian:buster-20210408-slim",
+    "armv7": "arm32v7/debian:buster-20210408-slim"
   }
 }


### PR DESCRIPTION
Bump base image from `debian:buster-20210329-slim` to `debian:buster-20210408-slim`.