### PR TITLE
Add docker to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+  - package-ecosystem: docker
+    directory: "/promtail"
+    schedule:
+      interval: daily

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,6 +1,3 @@
-# https://hub.docker.com/_/debian
-ARG BUILD_FROM=amd64/debian:buster-20210329-slim
-
 # https://hub.docker.com/_/golang
 FROM golang:1.16.3-buster as build
 # https://github.com/grafana/loki/releases
@@ -25,8 +22,8 @@ RUN set -eux; \
 WORKDIR /src/loki
 RUN make BUILD_IN_CONTAINER=false promtail
 
-# hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+# https://hub.docker.com/_/debian
+FROM debian:buster-20210329-slim
 
 COPY --from=build /src/loki/cmd/promtail/promtail /usr/bin/promtail
 RUN promtail --version

--- a/promtail/build.json
+++ b/promtail/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "aarch64": "arm64v8/debian:buster-20210408-slim",
-    "amd64": "amd64/debian:buster-20210408-slim",
-    "armhf": "arm32v5/debian:buster-20210408-slim",
-    "armv7": "arm32v7/debian:buster-20210408-slim"
+    "aarch64": "arm64v8/debian",
+    "amd64": "amd64/debian",
+    "armhf": "arm32v5/debian",
+    "armv7": "arm32v7/debian"
   }
 }


### PR DESCRIPTION
Let dependabot keep the dockerfile up to date (well at least the parts it understands). Also change dockerfile to use normal `FROM` statements so dependabot can understand more of it.