### PR TITLE
Update to Promtail `2.4.1`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,7 +1,7 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.17.3-bullseye as build
 # https://github.com/grafana/loki/releases
-ENV LOKI_VERSION 2.3.0
+ENV LOKI_VERSION 2.4.1
 
 # Must build binary from source on system with journal support. Published binaries on release do not include this.
 # https://packages.debian.org/buster/libsystemd-dev


### PR DESCRIPTION
Update from Promtail `2.3.0` to [2.4.1](https://github.com/grafana/loki/releases/tag/v2.4.1) (note this also covers the more significant bump to minor version [2.4.0](https://github.com/grafana/loki/releases/tag/v2.4.0))