### PR TITLE
Remove `GITHUB_TOKEN` input from all workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,5 +18,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/addon-ci.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,4 +12,3 @@ jobs:
     uses: mdegat01/addon-workflows/.github/workflows/base-deploy.yaml@main
     secrets:
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/labels.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/lock.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -13,5 +13,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/pr-labels.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/release-drafter.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/stale.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove unnecessary `GITHUB_TOKEN` input from all workflows as it breaks things.