### PR TITLE
Bump golang to 1.17.9-bullseye

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/golang
-FROM golang:1.17.6-bullseye as build
+FROM golang:1.17.9-bullseye as build
 # https://github.com/grafana/loki/releases
 ENV LOKI_VERSION 2.4.2
 


### PR DESCRIPTION
Bumps golang from 1.17.6-bullseye to 1.17.9-bullseye
