### PR TITLE
Update promtail to `2.5.0`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,7 +1,7 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.17.9-bullseye as build
 # https://github.com/grafana/loki/releases
-ENV LOKI_VERSION 2.4.2
+ENV LOKI_VERSION 2.5.0
 
 # Must build binary from source on system with journal support. Published binaries on release do not include this.
 # https://packages.debian.org/buster/libsystemd-dev


### PR DESCRIPTION
Update promtail from `2.4.2` to [2.5.0](https://github.com/grafana/loki/releases/tag/v2.5.0)
