### PR TITLE
Update Loki to 2.7.0

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,7 +1,7 @@
 # https://hub.docker.com/_/golang
-FROM golang:1.18.5-bullseye as build
+FROM golang:1.19.2-bullseye as build
 # https://github.com/grafana/loki/releases
-ENV LOKI_VERSION 2.6.1
+ENV LOKI_VERSION 2.7.0
 
 WORKDIR /usr/src/loki
 
@@ -14,7 +14,7 @@ RUN set -eux; \
         ; \
     git clone --depth 1 -b "v${LOKI_VERSION}" https://github.com/grafana/loki .; \
     make clean; \
-    make BUILD_IN_CONTAINER=false promtail
+    make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
 # https://hub.docker.com/_/debian
 FROM debian:bullseye-20221114-slim


### PR DESCRIPTION
Update promtail from `2.6.1` to [`2.7.0`](https://github.com/grafana/loki/releases/tag/v2.7.0). Also bump golang from `1.18.5-bullseye` to `1.19.2-bullseye` as that is what is used in the promtail build Dockerfile now.

Supercedes #111 