### PR TITLE
Update systemd and promtail version

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,23 +1,36 @@
 # https://hub.docker.com/_/golang
-FROM golang:1.19.2-bullseye as build
+FROM golang:1.20.6-bullseye as build
 # https://github.com/grafana/loki/releases
-ENV LOKI_VERSION 2.7.0
+ENV LOKI_VERSION 2.8.4
 
 WORKDIR /usr/src/loki
 
 # Must build binary from source on system with journal support. Published binaries on release do not include this.
 # https://packages.debian.org/buster/libsystemd-dev
 RUN set -eux; \
+    echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list; \
     apt-get update; \
-    apt-get install -qy --no-install-recommends \ 
-    libsystemd-dev=247.3-7+deb11u1 \
-        ; \
+    apt-get install -qy --no-install-recommends \
+    -t bullseye-backports libsystemd-dev=252.5-2~bpo11+1; \
+    \
     git clone --depth 1 -b "v${LOKI_VERSION}" https://github.com/grafana/loki .; \
     make clean; \
     make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
 # https://hub.docker.com/_/debian
-FROM debian:bullseye-20221114-slim
+FROM debian:bullseye-20230814-slim
+
+# tzdata required for the timestamp stage to work
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+# See https://github.com/grafana/loki/blob/v2.8.4/clients/cmd/promtail/Dockerfile#L12C1-L13C121 for more details
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && \
+  apt-get install -qy --no-install-recommends \
+  tzdata ca-certificates; \
+  apt-get install -qy --no-install-recommends \
+  -t bullseye-backports libsystemd-dev=252.5-2~bpo11+1; \
+  \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build /usr/src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 RUN promtail --version


### PR DESCRIPTION
# Proposed Changes

This PR updates promtail version 2.84 and is using a newer base image.

## Related Issues

- N/A